### PR TITLE
Batch-Write

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,10 @@
     "cSpell.words": [
         "innermain",
         "Ngrok"
-    ]
+    ],
+    "[markdown]": {
+        "editor.wordWrap": "wordWrapColumn",
+        "editor.wordWrapColumn": 800,
+        "diffEditor.wordWrap": "off"
+    }
 }

--- a/Gallery-Server/pom.xml
+++ b/Gallery-Server/pom.xml
@@ -28,42 +28,33 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
-
     <dependency>
       <groupId>org.jboss.weld.environment</groupId>
       <artifactId>weld-environment-common</artifactId>
       <version>5.0.0.SP2</version>
     </dependency>
-
-
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-bom</artifactId>
       <version>5.0.1.Final</version>
       <type>pom</type>
     </dependency>
-
-
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-extensions-parent</artifactId>
       <version>1.0.0.Beta1</version>
       <type>pom</type>
     </dependency>
-
-
     <dependency>
       <groupId>com.github.alexdlaird</groupId>
       <artifactId>java-ngrok</artifactId>
       <version>1.5.6</version>
     </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
       <version>2.7.0</version>
     </dependency>
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
@@ -91,6 +82,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/Gallery-Server/src/main/java/edu/yu/cs/gallery/ArtResource.java
+++ b/Gallery-Server/src/main/java/edu/yu/cs/gallery/ArtResource.java
@@ -9,7 +9,11 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
+import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response.Status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.*;
 
 
@@ -28,7 +32,7 @@ public class ArtResource {
     @Inject 
     Utility utility;
 
-
+// ---------------------------------------Single-Requests--------------------------------------------//    
     @GET
     @Path("/{gallery-id}/arts")
     public Response getAll(
@@ -36,78 +40,129 @@ public class ArtResource {
             @QueryParam("name") String name,
             @QueryParam("creator") String creator, @Context UriInfo uriInfo) throws URISyntaxException {
         if (utility.gallery == null || galleryId != utility.gallery.id) {
-            return utility.redirect(galleryId, uriInfo);
+            return utility.temporaryRedirect(galleryId, uriInfo);
         }
         return Response.status(Status.OK).entity(ar.search(galleryId, name, creator)).build();
     }
     
-    @GET
-    @Path("/batch/arts")
-    public Response getOnServer(@QueryParam("gallery") long[] galleries, @Context UriInfo uriInfo) throws URISyntaxException {
-        return utility.redirect(galleries, uriInfo);
-    }
-    
     @POST
     @Transactional
     @Path("/{gallery-id}/arts")
-    //Create a piece of art within the gallery of the ID given by the path parameter
-    public Response create(@PathParam("gallery-id") long galleryId, Art art, @Context UriInfo uriInfo) throws URISyntaxException {
-        if (utility.gallery == null || galleryId != utility.gallery.id) {
-            return utility.redirect(galleryId, uriInfo);
+    //POST method 
+    //Object obj is a filler to enable either an Art or Art array to be passed in to a single endpoint and handled correctly. 
+    //An attempt is made to deserialize as either Art or Art array, if it fails a BAD_REQUEST status is returned 
+    public Response creates(@PathParam("gallery-id") long galleryId, Object obj, @Context UriInfo uriInfo) throws URISyntaxException {
+        ObjectMapper om = new ObjectMapper();
+        try {
+            Art art = om.convertValue(obj, Art.class);
+            return create(galleryId, art, uriInfo);
+        } catch (Exception e1) {
+            try {
+                Art[] arts = om.convertValue(obj, Art[].class);
+                return create(galleryId, arts, uriInfo);
+            } catch (Exception e2) {
+                return Response.status(Status.BAD_REQUEST).build();
+            }
         }
-        art.gallery = utility.gallery;
-        ar.persist(art);
-        if (!ar.isPersistent(art)) {
-            throw new NotFoundException();
-        }
-        UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
-        uriBuilder.path(Long.toString(art.id));
-        return Response.created(uriBuilder.build()).entity(art).status(Status.CREATED).build();
     }
     
+            //Create a single piece of art within the gallery of the ID given by the path parameter
+            private Response create(long galleryId, Art art, UriInfo uriInfo) throws URISyntaxException {
+                if (utility.gallery == null || galleryId != utility.gallery.id) {
+                    return utility.temporaryRedirect(galleryId, uriInfo);
+                }
+                art.gallery = utility.gallery;
+                ar.persist(art);
+                if (!ar.isPersistent(art)) {
+                    throw new NotFoundException();
+                }
+                UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
+                uriBuilder.path(Long.toString(art.id));
+                return Response.created(uriBuilder.build()).entity(art).status(Status.CREATED).build();
+            }
+            
+            //Create multiple pieces of art within the gallery of the ID given by the path parameter
+            public Response create(long galleryId, Art[] arts, UriInfo uriInfo) throws URISyntaxException {
+                if (utility.gallery == null || galleryId != utility.gallery.id) {
+                    return utility.temporaryRedirect(galleryId, uriInfo);
+                }
+                for (Art art : arts) {
+                    art.gallery = utility.gallery;
+                }
+                ar.persist(Arrays.asList(arts));
+                
+                return Response.status(Status.CREATED).entity(arts).build();
+            }
     
-    @POST
-    @Transactional
-    @Path("/{gallery-id}/arts")
-    //Create a piece of art within the gallery of the ID given by the path parameter
-    public Response create(@PathParam("gallery-id") long galleryId, List<Art> arts, @Context UriInfo uriInfo) throws URISyntaxException {
-        if (utility.gallery == null || galleryId != utility.gallery.id) {
-            return utility.redirect(galleryId, uriInfo);
-        }
-        for (Art art : arts) {
-            art.gallery = utility.gallery;
-        }
-        ar.persist(arts);
-        return Response.status(Status.CREATED).entity(arts).build();
-    }
-    
-  
     @PUT
     @Path("/{gallery-id}/arts/{id}")
     @Transactional
     //Replaces the piece of art that exists at a certain id in a certain gallery with a new one
-    public Response update(@PathParam("gallery-id") long galleryId, @PathParam("id") Long id, Art art, @Context UriInfo uriInfo) throws URISyntaxException {   
+    public Response update(@PathParam("gallery-id") long galleryId, @PathParam("id") Long id, Art art, @Context UriInfo uriInfo) throws URISyntaxException {
         if (utility.gallery == null || galleryId != utility.gallery.id) {
-           return utility.redirect(galleryId, uriInfo);
-        }    
-        Art entity = ar.findById(id);
-        if (entity == null) {
+            return utility.temporaryRedirect(galleryId, uriInfo);
+        }
+        Art currentArt = ar.findById(id);
+        if (currentArt == null) {
             return Response.status(NOT_FOUND).build();
         }
-        
-        entity.name = art.name;
-        entity.creator = art.creator;
 
-        return Response.status(Status.OK).entity(entity).build();
-    } 
+        currentArt.name = art.name;
+        currentArt.creator = art.creator;
+
+        return Response.status(Status.OK).entity(currentArt).build();
+    }
+    
+    @PUT
+    @Transactional
+    @Path("/{gallery-id}/arts")
+    // Create a piece of art within the gallery of the ID given by the path parameter
+    public Response update(@PathParam("gallery-id") long galleryId, List<Art> arts, @Context UriInfo uriInfo) throws URISyntaxException {
+        if (utility.gallery == null || galleryId != utility.gallery.id) {
+            return utility.temporaryRedirect(galleryId, uriInfo);
+        }
+    
+        List<Art> successfulArts = new ArrayList<>();
+        for (Art art : arts) {
+            Art currentArt = ar.findById(art.id);
+            if (currentArt == null) {
+                return Response.status(NOT_FOUND).entity(successfulArts).build();
+            }
+            currentArt.name = art.name;
+            currentArt.creator = art.creator;
+            successfulArts.add(art);
+        }
+        return Response.status(Status.OK).entity(arts).build();
+    }   
 
     @DELETE
     @Path("/{gallery-id}/arts/{id}")
     @Transactional
-    public Response deleteById(@PathParam("gallery-id") long galleryId, @PathParam("id") Long id, @Context UriInfo uriInfo) throws URISyntaxException {   
+    public Response deleteById(@PathParam("gallery-id") long galleryId, @PathParam("id") Long id,
+            @Context UriInfo uriInfo) throws URISyntaxException {
         if (utility.gallery == null || galleryId != utility.gallery.id) {
-            return utility.redirect(galleryId, uriInfo);
-        }     
+            return utility.temporaryRedirect(galleryId, uriInfo);
+        }
         return ar.deleteById(id) ? Response.noContent().build() : Response.status(BAD_REQUEST).build();
     }
+    
+//---------------------------------------Batch-Requests--------------------------------------------//
+    @GET
+    @Path("/batch/arts")
+    public Response getOnServer(@QueryParam("gallery") long[] galleryIDs, @Context UriInfo uriInfo, @Context Request request) throws URISyntaxException {
+        return utility.readRedirect(galleryIDs, uriInfo, request);
+    }
+    
+    @POST
+    @Path("/batch/arts")
+    public Response postOnServer(@Context UriInfo uriInfo, @Context Request request, Gallery[] galleries) throws URISyntaxException {
+        return utility.writeRedirect(galleries, uriInfo, request);
+    }
+    
+    @PUT
+    @Path("/batch/arts")
+    public Response putOnServer(@Context UriInfo uriInfo, @Context Request request, Gallery[] galleries) throws URISyntaxException {
+        return utility.writeRedirect(galleries, uriInfo, request);
+    }
+    
 }

--- a/Gallery-Server/src/main/java/edu/yu/cs/gallery/ArtResource.java
+++ b/Gallery-Server/src/main/java/edu/yu/cs/gallery/ArtResource.java
@@ -10,6 +10,7 @@ import javax.transaction.Transactional;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.Status;
+import java.util.*;
 
 
 import edu.yu.cs.gallery.repositories.ArtRepository;
@@ -63,6 +64,23 @@ public class ArtResource {
         uriBuilder.path(Long.toString(art.id));
         return Response.created(uriBuilder.build()).entity(art).status(Status.CREATED).build();
     }
+    
+    
+    @POST
+    @Transactional
+    @Path("/{gallery-id}/arts")
+    //Create a piece of art within the gallery of the ID given by the path parameter
+    public Response create(@PathParam("gallery-id") long galleryId, List<Art> arts, @Context UriInfo uriInfo) throws URISyntaxException {
+        if (utility.gallery == null || galleryId != utility.gallery.id) {
+            return utility.redirect(galleryId, uriInfo);
+        }
+        for (Art art : arts) {
+            art.gallery = utility.gallery;
+        }
+        ar.persist(arts);
+        return Response.status(Status.CREATED).entity(arts).build();
+    }
+    
   
     @PUT
     @Path("/{gallery-id}/arts/{id}")

--- a/Gallery-Server/src/main/java/edu/yu/cs/gallery/GalleryResource.java
+++ b/Gallery-Server/src/main/java/edu/yu/cs/gallery/GalleryResource.java
@@ -20,10 +20,11 @@ import javax.ws.rs.core.Response.Status;
 import static javax.ws.rs.core.Response.Status.*;
 
 import org.springframework.http.*;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.reactive.function.client.WebClient;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import edu.yu.cs.gallery.Utility.Runnable;
+
 
 @Path("/galleries")
 @ApplicationScoped
@@ -48,7 +49,7 @@ public class GalleryResource {
 
     @GET
     public Response getOnServer() {
-    return Response.status(Status.OK).entity(gr.findAll().firstResult()).build();
+        return Response.status(Status.OK).entity(gr.findAll().firstResult()).build();
     }
 
     @GET
@@ -58,12 +59,6 @@ public class GalleryResource {
             return utility.temporaryRedirect(id, uriInfo);
         }
         return Response.status(Status.OK).entity(gr.findById(id)).build();
-    }
-    
-    @POST
-    @Path("/test") 
-    public String get (@Context Request request, @Context UriInfo uriInfo, @RequestBody String requestBody) {
-        return requestBody;
     }
 
     @PUT
@@ -154,30 +149,24 @@ public class GalleryResource {
     //Hub talks to the gallery and sets the map of the IDs to the URLs.
     @POST 
     @Path("/servers")
-    public Response updateIPs(Map<Long, URL> as) {
+    public void updateIPs(Map<Long, URL> as) {
         utility.allServers = as;
-        if (utility.allServers.equals(as)) {
-            return Response.status(Status.OK).build();
-        }
-        return Response.status(INTERNAL_SERVER_ERROR).build();
     }
     
     // Hub talks to the gallery and sets the leaderID.
     @POST 
     @Path("/leader")
-    public Response updateLeader(Long leaderID) {
+    public void updateLeader(Long leaderID) {
         utility.leaderID = leaderID;
-        if (utility.leaderID.equals(leaderID)) {
-            return Response.status(Status.OK).build();
-        }
-        return Response.status(INTERNAL_SERVER_ERROR).build();
     }
 
 // ---------------------------------------Batch-Requests--------------------------------------------//
     @GET
     @Path("/batch")
     public Response getOnServer(@QueryParam("gallery") long[] galleries, @Context UriInfo uriInfo, @Context Request request) throws URISyntaxException {
-        return utility.readRedirect(galleries, uriInfo, request);
+        Runnable<Response> localMethod = (Gallery gl) -> getById(gl.id, uriInfo);
+    
+        return utility.readRedirect(galleries, uriInfo, request, localMethod);
     }
 
     // For testing purposes

--- a/Gallery-Server/src/main/java/edu/yu/cs/gallery/Utility.java
+++ b/Gallery-Server/src/main/java/edu/yu/cs/gallery/Utility.java
@@ -10,6 +10,7 @@ import javax.inject.Singleton;
 import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.Status;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,9 @@ public class Utility {
     @Inject
     GalleryRepository gr;
 
+    @ConfigProperty(name = "quarkus.http.port")
+    int port;
+
     //Forwards the URL to the client with a 307
     protected Response temporaryRedirect(long id, @Context UriInfo uriInfo) throws URISyntaxException {
         if (allServers.keySet().contains(id)) {
@@ -37,13 +41,13 @@ public class Utility {
     }
     
     //URI must contain the string "batch" in place of the galleryId 
-    @SuppressWarnings("all")
-    private int redirect(long galleryId, UriInfo uriInfo, HttpMethod httpMethod, Object body, List<Object> returnEntities) throws URISyntaxException {
-        WebClient webClient = WebClient.create(this.allServers.get(galleryId).toString());
-        
-        String path = uriInfo.getPath();
-        path = path.replace("batch", Long.toString(galleryId));
-        
+    private int redirect(long galleryId, UriInfo uriInfo, HttpMethod httpMethod, Object body,
+            List<Object> returnEntities) throws URISyntaxException {
+
+        WebClient webClient = WebClient.create(allServers.get(galleryId).toString());
+
+        String path = uriInfo.getPath().replace("batch", Long.toString(galleryId));
+
         ResponseEntity<Object> response = webClient.method(httpMethod)
                 .uri(path)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -52,21 +56,26 @@ public class Utility {
                 .toEntity(Object.class)
                 .block();
 
-        Object responseObject = response.getBody();
-        if (responseObject instanceof Collection) {
-            returnEntities.addAll((Collection)responseObject);
-        } else {
-            returnEntities.add(responseObject);
-        }
+        returnEntities.addAll(List.of(response.getBody()));
         return response.getStatusCodeValue();
     }
-    
-    protected Response readRedirect (long[] galleryIDs, UriInfo uriInfo, Request request) throws URISyntaxException {
+
+    protected Response readRedirect (long[] galleryIDs, UriInfo uriInfo, Request request, Runnable<Response> localMethod) throws URISyntaxException {
         List<Object> returnEntities = new ArrayList<>();
         
         for (long galleryID : galleryIDs) {
             if (allServers.containsKey(galleryID)) {
-                int statusCode = this.redirect(galleryID, uriInfo, HttpMethod.valueOf(request.getMethod()), "", returnEntities);
+                int statusCode;
+                
+                if (galleryID == gallery.id) {
+                    Response response = localMethod.run(this.gallery);
+                    returnEntities.addAll(List.of(response.getEntity()));
+                    statusCode = response.getStatus();
+                } else {
+                    statusCode = redirect(galleryID, uriInfo, HttpMethod.valueOf(request.getMethod()), "",
+                            returnEntities);
+                }
+                
                 if (statusCode != 200) {
                     return Response.status(statusCode).entity(returnEntities).build();
                 }
@@ -76,24 +85,38 @@ public class Utility {
         return Response.status(Status.OK).entity(returnEntities).build();
     }
     
-    protected Response writeRedirect(Gallery[] galleries, UriInfo uriInfo, Request request) throws URISyntaxException {
+    protected Response writeRedirect(Gallery[] galleries, UriInfo uriInfo, Request request, Runnable<Response> localMethod) throws URISyntaxException {
+
         //If the user attempts to make a batch write to a server that is not the leader, return a temporaryRedirect to the correct server.
-        if (this.gallery.id != leaderID) {
+        if (gallery.id != leaderID) {
             return temporaryRedirect(leaderID, uriInfo);
         }
 
         List<Object> returnEntities = new ArrayList<>();
-        
+
         for (Gallery gallery : galleries) {
-            if (allServers.containsKey(gallery.id)) {
-                int statusCode = this.redirect(gallery.id, uriInfo, HttpMethod.valueOf(request.getMethod()), gallery.artList, returnEntities);
+            if (allServers.containsKey(this.gallery.id)) {
+                int statusCode;
+
+                if (this.gallery.id == gallery.id) {
+                    Response response = localMethod.run(gallery);
+                    returnEntities.addAll(List.of(response.getEntity()));
+                    statusCode = response.getStatus();
+                } else {
+                    statusCode = redirect(gallery.id, uriInfo, HttpMethod.valueOf(request.getMethod()), gallery.artList, returnEntities);
+                }
+
                 if (statusCode != 200 && statusCode != 201) {
                     return Response.status(statusCode).entity(returnEntities).build();
                 }
             }
         }
-        
+
         return Response.status(Status.OK).entity(returnEntities).build();
     }
     
+    @FunctionalInterface
+    public interface Runnable<E> {
+        E run(Gallery gl) throws URISyntaxException;
+    }
 }

--- a/Hub-Server/pom.xml
+++ b/Hub-Server/pom.xml
@@ -28,20 +28,16 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
-
     <dependency>
       <groupId>com.github.alexdlaird</groupId>
       <artifactId>java-ngrok</artifactId>
       <version>1.5.6</version>
     </dependency>
-
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
       <version>2.7.0</version>
     </dependency>
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
@@ -73,6 +69,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/Hub-Server/src/main/java/edu/yu/cs/hub/GalleryInfo.java
+++ b/Hub-Server/src/main/java/edu/yu/cs/hub/GalleryInfo.java
@@ -9,5 +9,4 @@ import io.quarkus.hibernate.orm.panache.PanacheEntity;
 @Entity
 public class GalleryInfo extends PanacheEntity {
     public URL url;
-    public boolean isLeader = false;
 }

--- a/Hub-Server/src/main/java/edu/yu/cs/hub/GalleryInfo.java
+++ b/Hub-Server/src/main/java/edu/yu/cs/hub/GalleryInfo.java
@@ -9,4 +9,5 @@ import io.quarkus.hibernate.orm.panache.PanacheEntity;
 @Entity
 public class GalleryInfo extends PanacheEntity {
     public URL url;
+    public boolean isLeader = false;
 }

--- a/Hub-Server/src/main/java/edu/yu/cs/hub/GalleryInfoRepository.java
+++ b/Hub-Server/src/main/java/edu/yu/cs/hub/GalleryInfoRepository.java
@@ -8,7 +8,6 @@ import io.quarkus.hibernate.orm.panache.PanacheRepository;
 
 @ApplicationScoped
 public class GalleryInfoRepository implements PanacheRepository<GalleryInfo> {
-
     public Map<Long, URL> toMap() {
         Map<Long, URL> giMap = new HashMap<>();
         List<GalleryInfo> giList = listAll();
@@ -20,4 +19,7 @@ public class GalleryInfoRepository implements PanacheRepository<GalleryInfo> {
         return giMap;
     }
 
+    protected Long leaderId() {
+        return find("isLeader", true).firstResult().id;
+    }
 }

--- a/Hub-Server/src/main/java/edu/yu/cs/hub/GalleryInfoRepository.java
+++ b/Hub-Server/src/main/java/edu/yu/cs/hub/GalleryInfoRepository.java
@@ -18,8 +18,4 @@ public class GalleryInfoRepository implements PanacheRepository<GalleryInfo> {
 
         return giMap;
     }
-
-    protected Long leaderId() {
-        return find("isLeader", true).firstResult().id;
-    }
 }

--- a/Hub-Server/src/main/java/edu/yu/cs/hub/ServerStartUp.java
+++ b/Hub-Server/src/main/java/edu/yu/cs/hub/ServerStartUp.java
@@ -1,0 +1,21 @@
+package edu.yu.cs.hub;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+
+import io.quarkus.runtime.StartupEvent;
+
+@Singleton
+public class ServerStartUp {    
+    @Inject
+    Utility utility;
+    
+    @Transactional
+    public void init(@Observes StartupEvent se) {
+        utility.setLeaderID();
+        utility.updateServers();
+    }
+    
+}

--- a/Hub-Server/src/main/java/edu/yu/cs/hub/Utility.java
+++ b/Hub-Server/src/main/java/edu/yu/cs/hub/Utility.java
@@ -1,0 +1,64 @@
+package edu.yu.cs.hub;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
+
+import java.net.URL;
+import java.util.*;
+
+@Singleton
+public class Utility {
+    protected long hubLeaderID;
+    
+    @Inject 
+    GalleryInfoRepository galleryInfoRepo;
+    
+    protected void setLeaderID (){
+        if (galleryInfoRepo.count() > 0) {
+            Random random = new Random();
+            hubLeaderID = random.nextLong() % (galleryInfoRepo.count()) + 1;
+        }
+    }
+    
+    protected void updateServers() {
+        Map<Long, URL> allGI = galleryInfoRepo.toMap();
+        for (long currentId : allGI.keySet()) {
+            // Code to update each IP with the new data
+            URL url = galleryInfoRepo.toMap().get(currentId);
+            postMapToGallery(url);
+            postLeaderToGallery(url);
+        }
+    }
+    
+    //This method enables the URL map to be sent to URLs beyond those in the current URL map. 
+    //Current use-case is a DELETE, where the URL is deleted from the map, but the gallery located at that URL should still receive that updated map so that it can properly redirect requests. So, this method is called with otherURLs containing the URL of the deleted gallery.
+    //Future use-cases for this method might include exporting the URL map to backup servers, or doing a mass delete where more than one URL is deleted from the map and the map needs to be sent to many URLs which are now not present in the map.
+    protected void updateServers(List<URL> otherURLs) {
+        updateServers();
+        for (URL url : otherURLs) {
+            postMapToGallery(url);
+        }
+    }
+    
+    protected void postLeaderToGallery(URL url) {
+        WebClient webClient = WebClient.create(url.toString());
+        webClient.post()
+                .uri("/galleries/leader")
+                .body(Mono.just(hubLeaderID), Long.class)
+                .retrieve()
+                .bodyToMono(String.class).block();
+    }
+
+    protected void postMapToGallery(URL url) {
+        WebClient webClient = WebClient.create(url.toString());
+        webClient.post()
+                .uri("/galleries/servers")
+                .body(Mono.just(galleryInfoRepo.toMap()), Map.class)
+                .retrieve()
+                .bodyToMono(String.class).block();
+    }
+}


### PR DESCRIPTION
- Added bulk POST and PUT for Art (endpoints that accept an array of art)
- Added endpoints to accept batch PUT and POST requests (i.e. write requests) which will make bulk or single requests to many different servers
- Added new redirect methods to facilitate redirecting reads vs. writes
- Added flag to detemine leader in Hub and functionality to propogate that to all servers along with the URL map; redirects correctly work based on leader