### PR TITLE
Health Checks, Randomization Fix

### DIFF
--- a/Gallery-Server/src/main/java/edu/yu/cs/gallery/GalleryResource.java
+++ b/Gallery-Server/src/main/java/edu/yu/cs/gallery/GalleryResource.java
@@ -175,4 +175,11 @@ public class GalleryResource {
     public Map<Long, URL> IPs() {
         return utility.allServers;
     }
+
+    @Path("/leader")
+    @GET
+    public long leader() {
+        return utility.leaderID;
+    }
+
 }

--- a/Hub-Server/pom.xml
+++ b/Hub-Server/pom.xml
@@ -76,6 +76,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-scheduler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>

--- a/Hub-Server/src/main/java/edu/yu/cs/hub/AsynchronousEvents.java
+++ b/Hub-Server/src/main/java/edu/yu/cs/hub/AsynchronousEvents.java
@@ -1,0 +1,28 @@
+package edu.yu.cs.hub;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+
+
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.scheduler.Scheduled;
+
+@Singleton
+public class AsynchronousEvents {
+    @Inject
+    Utility utility;
+
+    @Transactional
+    public void init(@Observes StartupEvent se) {
+        utility.setLeaderID();
+        utility.updateServers();
+    }
+    
+    @Scheduled(every="10s")
+    public void healthCheck() {
+        utility.galleryHealthCheck();
+    }
+
+}

--- a/Hub-Server/src/main/java/edu/yu/cs/hub/Hub.java
+++ b/Hub-Server/src/main/java/edu/yu/cs/hub/Hub.java
@@ -50,7 +50,7 @@ public class Hub {
         }
         gi.url = url; 
         
-        utility.updateServers ();
+        utility.updateServers();
         return Response.status(Status.OK).build();
     }
     
@@ -65,4 +65,14 @@ public class Hub {
         }
         return deleted ? Response.noContent().build() : Response.status(BAD_REQUEST).build();
     }
+
+    // for testing
+    @GET
+    @Path("/resetleader")
+    public void resetLeader() {
+        utility.setLeaderID();
+        utility.updateServers();
+    }
 }
+
+


### PR DESCRIPTION
- Used Quarkus extensions to add health check endpoints to the gallery servers. 
- Health checks are made asynchronously by the hub; if a gallery is detected to be down, it is removed from the server list. If it is the leader (for the purpose of batch writes) a new leader is selected.
- Fixed a bug in the randomization to select a new leader.